### PR TITLE
pass inc and tt on heartbeat pixels as the proper units

### DIFF
--- a/ParselyTracker/EngagedTime.swift
+++ b/ParselyTracker/EngagedTime.swift
@@ -25,8 +25,8 @@ class EngagedTime: Sampler {
         if enableHeartbeats != true {
             return
         }
-        let roundedSecs: Int = Int(data.totalMs / 1000)  // logic check!
-        let totalMs: Int = Int(data.totalMs)
+        let roundedSecs: Int = Int(data.ms)
+        let totalMs: Int = Int(data.totalMs * 1000)
 
         let event = Event(params: [
             "date": Date().timeIntervalSince1970,

--- a/ParselyTracker/Track.swift
+++ b/ParselyTracker/Track.swift
@@ -25,6 +25,7 @@ class Track {
         // generic helper function, sends the event as-is
         self.pixel.beacon(additionalParams: event, shouldNotSetLastRequest: shouldNotSetLastRequest)
         os_log("Sending an event from Track")
+        dump(event)
 
     }
 


### PR DESCRIPTION
This pull request fixes the units on the `inc` and `tt` `heartbeat` parameters.

See https://github.com/Parsely/engineering/issues/2938 for details