### PR TITLE
don't accept metadata for engaged time

### DIFF
--- a/ParselyDemo/FirstViewController.swift
+++ b/ParselyDemo/FirstViewController.swift
@@ -29,7 +29,7 @@ class FirstViewController: UIViewController {
     
     @IBAction func didStartEngagement(_ sender: Any) {
         os_log("didStartEngagement", log: OSLog.default, type: .debug)
-        delegate.parsely.startEngagement(url: "http://parsely.com/very-not-real", urlref:"http://parsely.com/not-real", metadata: ["Author":"Yogi Berra"], extraData: ["product-id": "12345"], apikey: "engaged.parsely-test.com")
+        delegate.parsely.startEngagement(url: "http://parsely.com/very-not-real", urlref:"http://parsely.com/not-real", extraData: ["product-id": "12345"], apikey: "engaged.parsely-test.com")
     }
     
     @IBAction func didStopEngagement(_ sender: Any) {

--- a/ParselyTracker/EngagedTime.swift
+++ b/ParselyTracker/EngagedTime.swift
@@ -41,10 +41,10 @@ class EngagedTime: Sampler {
         Parsely.sharedInstance.track.event(event: event)
     }
     
-    func startInteraction(url: String, urlref: String = "", metadata: Dictionary<String, Any>?, extra_data: Dictionary<String, Any>?, idsite: String) {
+    func startInteraction(url: String, urlref: String = "", extra_data: Dictionary<String, Any>?, idsite: String) {
         endInteraction()
         os_log("Starting Interaction", log: OSLog.tracker, type: .debug)
-        let eventArgs = generateEventArgs(url: url, urlref: urlref, metadata: metadata, extra_data: extra_data, idsite: idsite)
+        let eventArgs = generateEventArgs(url: url, urlref: urlref, extra_data: extra_data, idsite: idsite)
         trackKey(key: url, contentDuration: nil, eventArgs: eventArgs);
         accumulators[url]!.isEngaged = true
     }

--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -87,17 +87,15 @@ public class Parsely {
      
      - Parameter url: The url of the page being engaged with
      - Parameter urlref: The url of the page that linked to the page being engaged with
-     - Parameter metadata: A dictionary of Parsely-formatted metadata for the page being engaged with
      - Parameter extraData: A dictionary of additional information to send with generated heartbeat events
      - Parameter apikey: The Parsely public API key for which the heartbeat events should be counted
      */
     public func startEngagement(url: String,
                                 urlref: String = "",
-                                metadata: Dictionary<String, Any>? = nil,
                                 extraData: Dictionary<String, Any>? = nil,
                                 apikey: String = Parsely.sharedInstance.apikey)
     {
-        track.startEngagement(url: url, urlref: urlref, metadata: metadata, extra_data: extraData, idsite: apikey)
+        track.startEngagement(url: url, urlref: urlref, extra_data: extraData, idsite: apikey)
     }
 
     /**

--- a/ParselyTracker/Sampler.swift
+++ b/ParselyTracker/Sampler.swift
@@ -94,7 +94,7 @@ class Sampler {
         accumulators.removeValue(forKey: key)
     }
 
-    public func generateEventArgs(url: String, urlref: String, metadata: Dictionary<String, Any>?, extra_data: Dictionary<String, Any>?, idsite: String) -> Dictionary<String, Any> {
+    public func generateEventArgs(url: String, urlref: String, metadata: Dictionary<String, Any>? = nil, extra_data: Dictionary<String, Any>?, idsite: String) -> Dictionary<String, Any> {
         // eventArgs: url, urlref, metadata for heartbeats
         var eventArgs: [String: Any] = ["urlref": urlref, "url": url, "idsite": idsite]
         if (metadata != nil) {

--- a/ParselyTracker/Track.swift
+++ b/ParselyTracker/Track.swift
@@ -61,8 +61,8 @@ class Track {
         videoManager.reset(url:url, vId:vId)
     }
 
-    func startEngagement(url: String, urlref: String = "", metadata:Dictionary<String, Any>?, extra_data: Dictionary<String, Any>?, idsite: String) {
-        self.engagedTime.startInteraction(url: url, urlref: urlref, metadata: metadata, extra_data: extra_data, idsite: idsite)
+    func startEngagement(url: String, urlref: String = "", extra_data: Dictionary<String, Any>?, idsite: String) {
+        self.engagedTime.startInteraction(url: url, urlref: urlref, extra_data: extra_data, idsite: idsite)
         os_log("track start engagement from Track", log: OSLog.tracker, type:.debug)
     }
 


### PR DESCRIPTION
This pull request removes support for metadata on `heartbeat` events, which is ok because the JS tracker doesn't send metadata on `heartbeat` events. This simplifies the Swift API for integrators.