### PR TITLE
don't cache request URL, but rebuild it on each request

### DIFF
--- a/ParselyTracker/RequestBuilder.swift
+++ b/ParselyTracker/RequestBuilder.swift
@@ -61,14 +61,12 @@ class RequestBuilder {
     }
 
     static func buildPixelEndpoint(now: Date?) -> String {
-        if self._baseURL == nil || now != nil {
-            let now: Date = now ?? Date()
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd-HH"
-            dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-            let dateString = dateFormatter.string(from: now)
-            self._baseURL = "https://srv-\(dateString).pixel.parsely.com/mobileproxy"
-        }
+        let now: Date = now ?? Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd-HH"
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        let dateString = dateFormatter.string(from: now)
+        self._baseURL = "https://srv-\(dateString).pixel.parsely.com/mobileproxy"
         return self._baseURL!
     }
     


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/engineering/issues/2978 by removing the caching logic for the url used for pixel requests.