### PR TITLE
don't allow secondsBetweenHeartbeats to be configured by users

### DIFF
--- a/ParselyTracker/ParselyTracker.swift
+++ b/ParselyTracker/ParselyTracker.swift
@@ -46,14 +46,13 @@ public class Parsely {
      
      - Parameter apikey: The Parsely public API key for which the pageview event should be counted. Can be overridden
                          on individual tracking method calls.
-     - Parameter secondsBetweenHeartbeats: TimeInterval representing how often heartbeat events should be tracked
      - Parameter handleLifecycle: If true, set up listeners to handle tracking across application lifecycle events.
                                   Defaults to true.
      */
-    public func configure(apikey: String, secondsBetweenHeartbeats: TimeInterval = 10, handleLifecycle: Bool = true) {
+    public func configure(apikey: String, handleLifecycle: Bool = true) {
         os_log("Configuring ParselyTracker", log: OSLog.tracker, type: .debug)
         self.apikey = apikey
-        self.config = ["secondsBetweenHeartbeats": secondsBetweenHeartbeats]
+        self.config = ["secondsBetweenHeartbeats": 10]
         if handleLifecycle {
             addApplicationObservers()
         }


### PR DESCRIPTION
This pull request makes `secondsBetweenHeartbeats` unconfigurable by users per https://github.com/Parsely/web/pull/8925#discussion_r259072612