### PR TITLE
fix pub_date json serialization

### DIFF
--- a/ParselyTracker/Metadata.swift
+++ b/ParselyTracker/Metadata.swift
@@ -48,7 +48,7 @@ public class ParselyMetadata {
             metas["link"] = canonical_url!
         }
         if pub_date != nil {
-            metas["pub_date"] = pub_date!
+            metas["pub_date"] = String(format:"%i", pub_date!.timeIntervalSince1970 * 1000)
         }
         if title != nil {
             metas["title"] = title!

--- a/ParselyTrackerTests/MetadataTests.swift
+++ b/ParselyTrackerTests/MetadataTests.swift
@@ -39,12 +39,13 @@ class MetadataTests: ParselyTestCase {
             duration: expected["duration"] as? TimeInterval
         )
         let actual: Dictionary<String, Any> = metasUnderTest.toDict()
+        let pubDateUnix: String = String(format:"%i", (expected["pub_date"]! as! Date).timeIntervalSince1970 * 1000)
         XCTAssertFalse(actual.isEmpty, "Creating a ParselyMetadataobject with many parameters results in a " +
                        "non-empty object")
         XCTAssertEqual(actual["link"]! as! String, expected["canonical_url"]! as! String,
                        "The link field in the result of ParselyMetadata.toDict should match the canonical_url argument " +
                        "used at initialization")
-        XCTAssertEqual(actual["pub_date"]! as! Date, expected["pub_date"]! as! Date,
+        XCTAssertEqual(actual["pub_date"]! as! String, pubDateUnix,
                        "The pub_date field in the result of ParselyMetadata.toDict should match the pub_date argument " +
                        "used at initialization")
         XCTAssertEqual(actual["title"]! as! String, expected["title"]! as! String,

--- a/ParselyTrackerTests/RequestBuilderTests.swift
+++ b/ParselyTrackerTests/RequestBuilderTests.swift
@@ -3,11 +3,21 @@ import XCTest
 
 class RequestBuilderTests: ParselyTestCase {
     private func makeEvents() -> Array<Event> {
+        let exampleMetadata: ParselyMetadata = ParselyMetadata(
+            canonical_url:"http://parsely-test.com",
+            pub_date: Date(timeIntervalSince1970: 3),
+            title: "a title.",
+            authors: ["Yogi Berra"],
+            image_url: "http://parsely-test.com/image2",
+            section: "Things my mother says",
+            tags: ["tag1", "tag2"],
+            duration: TimeInterval(100)
+        )
         return [Event(
             "pageview",
             url: "http://test.com",
             urlref: nil,
-            metadata: nil, 
+            metadata: exampleMetadata,
             extra_data: nil
             )]
     }
@@ -54,6 +64,16 @@ class RequestBuilderTests: ParselyTestCase {
         XCTAssertEqual(actualEvents.count, events.count,
                        "RequestBuilder.buildRequest should return a request with an events array containing all " +
                        "relevant revents")
+    }
+    
+    func testParamsJson() {
+        let events = makeEvents()
+        let request = RequestBuilder.buildRequest(events: events)
+        var jsonData: Data? = nil
+        do {
+            jsonData = try JSONSerialization.data(withJSONObject: request!.params)
+        } catch { }
+        XCTAssertNotNil(jsonData, "Request params should serialize to JSON")
     }
     
     func testGetHardwareString() {


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/web/issues/9712 by converting `pub_date` to a JSON-serializable format before attempting to serialize it.