### PR TITLE
send sts as milliseconds rather than seconds

### DIFF
--- a/ParselyTracker/Session.swift
+++ b/ParselyTracker/Session.swift
@@ -29,7 +29,7 @@ class SessionManager {
             session["session_id"] = visitorInfo["session_count"]
             session["session_url"] = url
             session["session_referrer"] = urlref
-            session["session_ts"] = Int(Date().timeIntervalSince1970)
+            session["session_ts"] = Int(Date().timeIntervalSince1970 * 1000.0)
             session["last_session_ts"] = visitorInfo["last_session_ts"]
             
             visitorInfo["last_session_ts"] = session["session_ts"]


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/engineering/issues/3481 by sending `sts` as milliseconds rather than seconds.