### PR TITLE
Use UInt64 for rand timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,27 @@
 language: swift
-osx_image: xcode10.1
-xcode_workspace: ParselyDemo.xcworkspace
-xcode_scheme: ParselyTrackerTests
-xcode_destination: platform=iOS Simulator,OS=11.4,name=iPhone X
-before_install:
-  - pod repo update
+os: osx
+
+git:
+  depth: 1
+
+stages:
+  - name: test
+
+jobs:
+  include:
+    - stage: test
+      name: Run Unit Tests (iOS 10.3.1, iPhone 5)
+      osx_image: xcode10.1
+      xcode_workspace: ParselyDemo.xcworkspace
+      xcode_scheme: ParselyTrackerTests
+      xcode_destination: platform=iOS Simulator,OS=10.3.1,name=iPhone 5
+      before_install:
+        - pod repo update
+    - stage: test
+      name: Run Unit Tests (iOS 11.4, iPhone X)
+      osx_image: xcode10.1
+      xcode_workspace: ParselyDemo.xcworkspace
+      xcode_scheme: ParselyTrackerTests
+      xcode_destination: platform=iOS Simulator,OS=11.4,name=iPhone X
+      before_install:
+        - pod repo update

--- a/ParselyDemo.xcodeproj/project.pbxproj
+++ b/ParselyDemo.xcodeproj/project.pbxproj
@@ -763,7 +763,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -816,7 +816,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -833,6 +833,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = N3Z6SG5Z94;
 				INFOPLIST_FILE = ParselyDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.ParselyDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -850,6 +851,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = N3Z6SG5Z94;
 				INFOPLIST_FILE = ParselyDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.ParselyDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -867,6 +869,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = N3Z6SG5Z94;
 				INFOPLIST_FILE = AnalyticsSDKTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.AnalyticsSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -885,6 +888,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = N3Z6SG5Z94;
 				INFOPLIST_FILE = AnalyticsSDKTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.AnalyticsSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -908,6 +912,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ParselyTracker/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.ParselyTracker;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -933,6 +938,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ParselyTracker/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.ParselyTracker;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -952,7 +958,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = N3Z6SG5Z94;
 				INFOPLIST_FILE = ParselyTrackerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.ParselyTrackerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
@@ -969,7 +977,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = N3Z6SG5Z94;
 				INFOPLIST_FILE = ParselyTrackerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.parsely.ParselyTrackerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;

--- a/ParselyTracker/Event.swift
+++ b/ParselyTracker/Event.swift
@@ -14,7 +14,7 @@ class Event {
     var session_referrer: String?
     var last_session_timestamp: Int?
     var parsely_site_uuid: String?
-    var rand: Int!
+    var rand: UInt64!
     
     init(_ action: String,
          url: String,

--- a/ParselyTracker/Metadata.swift
+++ b/ParselyTracker/Metadata.swift
@@ -48,7 +48,7 @@ public class ParselyMetadata {
             metas["link"] = canonical_url!
         }
         if pub_date != nil {
-            metas["pub_date"] = String(format:"%i", pub_date!.timeIntervalSince1970 * 1000)
+            metas["pub_date"] = String(format:"%i", pub_date!.millisecondsSince1970)
         }
         if title != nil {
             metas["title"] = title!

--- a/ParselyTracker/Session.swift
+++ b/ParselyTracker/Session.swift
@@ -29,7 +29,7 @@ class SessionManager {
             session["session_id"] = visitorInfo["session_count"]
             session["session_url"] = url
             session["session_referrer"] = urlref
-            session["session_ts"] = Int(Date().timeIntervalSince1970 * 1000.0)
+            session["session_ts"] = Date().millisecondsSince1970
             session["last_session_ts"] = visitorInfo["last_session_ts"]
             
             visitorInfo["last_session_ts"] = session["session_ts"]

--- a/ParselyTracker/Storage.swift
+++ b/ParselyTracker/Storage.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 extension Date {
-    var millisecondsSince1970:Int {
-        return Int((self.timeIntervalSince1970 * 1000.0).rounded())
+    var millisecondsSince1970:UInt64 {
+        return UInt64(floor(self.timeIntervalSince1970 * 1000))
     }
     
-    init(milliseconds:Int) {
+    init(milliseconds:UInt64) {
         self = Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000)
     }
 }

--- a/ParselyTrackerTests/EventQueueTests.swift
+++ b/ParselyTrackerTests/EventQueueTests.swift
@@ -36,7 +36,7 @@ class EventQueueTests: ParselyTestCase {
     }
     
     func testGetTooMany() {
-        XCTAssert(self.queue.get(count:99999999999) == [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30])
+        XCTAssert(self.queue.get(count:2147483647) == [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30])
     }
     
     func testNegativeCount() {

--- a/ParselyTrackerTests/EventTests.swift
+++ b/ParselyTrackerTests/EventTests.swift
@@ -115,7 +115,7 @@ class EventTests: ParselyTestCase {
         XCTAssertEqual(actualExtraData["parsely_site_uuid"] as! String, expectedVisitorID,
                        "A visitor ID provided via Event.setVisitorInfo should be accessible in the result of " +
                        "Event.toDict as data[\"parsely_site_uuid\"]")
-        XCTAssert((actualExtraData["ts"] as! Int) > timestampInThePast,
+        XCTAssert((actualExtraData["ts"] as! UInt64) > timestampInThePast,
                   "The data.ts field of the result of Event.toDict should be a non-ancient timestamp")
     }
     

--- a/ParselyTrackerTests/MetadataTests.swift
+++ b/ParselyTrackerTests/MetadataTests.swift
@@ -39,7 +39,7 @@ class MetadataTests: ParselyTestCase {
             duration: expected["duration"] as? TimeInterval
         )
         let actual: Dictionary<String, Any> = metasUnderTest.toDict()
-        let pubDateUnix: String = String(format:"%i", (expected["pub_date"]! as! Date).timeIntervalSince1970 * 1000)
+        let pubDateUnix: String = String(format:"%i", (expected["pub_date"]! as! Date).millisecondsSince1970)
         XCTAssertFalse(actual.isEmpty, "Creating a ParselyMetadataobject with many parameters results in a " +
                        "non-empty object")
         XCTAssertEqual(actual["link"]! as! String, expected["canonical_url"]! as! String,

--- a/ParselyTrackerTests/SessionTests.swift
+++ b/ParselyTrackerTests/SessionTests.swift
@@ -23,9 +23,9 @@ class SessionTests: ParselyTestCase {
                        "The session_url of a newly-created session should be the url it was initialized with")
         XCTAssertEqual(session["session_referrer"] as! String, testSubsequentUrl,
                        "The session_referrer of a newly-created session should be the urlref it was initialized with")
-        XCTAssertGreaterThan(session["session_ts"] as! Int, epochTimeInThePast,
+        XCTAssertGreaterThan(session["session_ts"] as! UInt64, UInt64(epochTimeInThePast),
                              "The session_ts of a newly-created session should be non-ancient")
-        XCTAssertGreaterThan(session["last_session_ts"] as! Int, epochTimeInThePast,
+        XCTAssertGreaterThan(session["last_session_ts"] as! UInt64, UInt64(epochTimeInThePast),
                              "The last_session_ts of a newly-created session should be non-ancient")
     }
 
@@ -48,10 +48,10 @@ class SessionTests: ParselyTestCase {
         let session = sessions.get(url: testInitialUrl, urlref: testSubsequentUrl)
         let mutatedVisitor = visitorManager.getVisitorInfo()
         let expectedSessionCount = initialSessionCount + 1
-        let expectedLastSessionTs: Int = session["session_ts"] as! Int
+        let expectedLastSessionTs: UInt64 = session["session_ts"] as! UInt64
         XCTAssertEqual(mutatedVisitor["session_count"] as! Int, expectedSessionCount,
                        "The visitor's session_count should have been incremented after a call to SessionManager.get")
-        XCTAssertEqual(mutatedVisitor["last_session_ts"] as! Int, expectedLastSessionTs,
+        XCTAssertEqual(mutatedVisitor["last_session_ts"] as! UInt64, UInt64(expectedLastSessionTs),
                        "The visitor's last_session_ts should have been set to the session's session_ts after a call to " +
                        "SessionManager.get")
     }

--- a/ParselyTrackerTests/VisitorTests.swift
+++ b/ParselyTrackerTests/VisitorTests.swift
@@ -18,7 +18,7 @@ class VisitorTests: ParselyTestCase {
         XCTAssertEqual(visitor["session_count"] as! Int, subsequentVisitor["session_count"] as! Int,
                        "Sequential calls to VisitorManager.getVisitorInfo within the default expiry should return objects " +
                        "with the same session count")
-        XCTAssertEqual(visitor["last_session_ts"] as! Int, subsequentVisitor["last_session_ts"] as! Int,
+        XCTAssertEqual(visitor["last_session_ts"] as! UInt64, subsequentVisitor["last_session_ts"] as! UInt64,
                        "Sequential calls to VisitorManager.getVisitorInfo within the default expiry should return objects " +
                        "with the same last session timestamp")
     }


### PR DESCRIPTION
Switch from `Int` to `UInt64` to support big integers on 32-bit devices.

Resolves: https://github.com/Parsely/web/issues/10256