### PR TITLE
Upgrade http client to alamofire

### DIFF
--- a/ParselyDemo.xcodeproj/project.pbxproj
+++ b/ParselyDemo.xcodeproj/project.pbxproj
@@ -535,14 +535,14 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ParselyDemo/Pods-ParselyDemo-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftHTTP/SwiftHTTP.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftHTTP.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -769,6 +769,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -820,6 +821,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/ParselyTracker/HttpClient.swift
+++ b/ParselyTracker/HttpClient.swift
@@ -1,17 +1,16 @@
 import Foundation
 import os.log
 
-import SwiftHTTP
+import Alamofire
 
 class HttpClient {
     static func sendRequest(request: ParselyRequest) {
         os_log("Sending request to %s", log: OSLog.tracker, type: .debug, request.url)
-        HTTP.POST(request.url, parameters: request.params, headers:request.headers as? [String: String],
-                  requestSerializer: JSONParameterSerializer())
-        { response in
+        
+        Alamofire.request(request.url, method: .post, parameters: request.params, encoding: JSONEncoding.default, headers: request.headers as? HTTPHeaders).responseJSON {
+            (response) in
             if let err = response.error {
-                os_log("Request failed: %s", log: OSLog.tracker, type: .error,
-                       err.localizedDescription)
+                os_log("Request failed: %s", log: OSLog.tracker, type: .error, err.localizedDescription)
                 // TODO retry in response to specific errors here
                 // retry only needs to happen on timeouts or similar connection failures, not 500 or 404
             } else {

--- a/ParselyTracker/Pixel.swift
+++ b/ParselyTracker/Pixel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftHTTP
 import os.log
 
 class Pixel {

--- a/Podfile
+++ b/Podfile
@@ -6,11 +6,10 @@ target 'ParselyDemo' do
   use_frameworks!
 
   pod 'SwiftyJSON', '~> 4.2.0'
-  pod 'SwiftHTTP', '~> 3.0.1'
+  pod 'Alamofire', '~> 4.8.2'
   pod 'ReachabilitySwift', '~> 4.3.0'
   target 'ParselyDemoTests' do
     inherit! :search_paths
-
     # Pods for testing
   end
 
@@ -22,7 +21,7 @@ target 'ParselyTracker' do
 
   # Pods for ParselyTracker
   pod 'SwiftyJSON', '~> 4.2.0'
-  pod 'SwiftHTTP', '~> 3.0.1'
+  pod 'Alamofire', '~> 4.8.2'
   pod 'ReachabilitySwift', '~> 4.3.0'
   target 'ParselyTrackerTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
+  - Alamofire (4.8.2)
   - ReachabilitySwift (4.3.0)
-  - SwiftHTTP (3.0.1)
   - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
+  - Alamofire (~> 4.8.2)
   - ReachabilitySwift (~> 4.3.0)
-  - SwiftHTTP (~> 3.0.1)
   - SwiftyJSON (~> 4.2.0)
 
 SPEC REPOS:
   trunk:
+    - Alamofire
     - ReachabilitySwift
-    - SwiftHTTP
     - SwiftyJSON
 
 SPEC CHECKSUMS:
+  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   ReachabilitySwift: 408477d1b6ed9779dba301953171e017c31241f3
-  SwiftHTTP: e94f1aa8cde58637dcc0100f6349de31a3337fde
   SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: 5108c08fa9243da1573d11cb9b4a29b410d9be7f
+PODFILE CHECKSUM: 3cec596aa3c663ed0602098e4ef5b6759b237d49
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
This swaps out SwiftHTTP for Alamofire. SwiftHTTP was unsupported and written in swift 3 so incompatible with newer versions of Xcode. 

Associated with: https://github.com/Parsely/engineering/issues/3700