### PR TITLE
specify minor version ranges instead of bugfix version ranges

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,9 +5,9 @@ target 'ParselyDemo' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'SwiftyJSON', '~> 4.2.0'
-  pod 'Alamofire', '~> 4.8.2'
-  pod 'ReachabilitySwift', '~> 4.3.0'
+  pod 'SwiftyJSON', '~> 4.2'
+  pod 'Alamofire', '~> 4.8'
+  pod 'ReachabilitySwift', '~> 4.3'
   target 'ParselyDemoTests' do
     inherit! :search_paths
     # Pods for testing
@@ -20,9 +20,9 @@ target 'ParselyTracker' do
   use_frameworks!
 
   # Pods for ParselyTracker
-  pod 'SwiftyJSON', '~> 4.2.0'
-  pod 'Alamofire', '~> 4.8.2'
-  pod 'ReachabilitySwift', '~> 4.3.0'
+  pod 'SwiftyJSON', '~> 4.2'
+  pod 'Alamofire', '~> 4.8'
+  pod 'ReachabilitySwift', '~> 4.3'
   target 'ParselyTrackerTests' do
     inherit! :search_paths
     # Pods for testing


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/web/issues/10462 by changing the Podfile's dependencies to specify major versions instead of minor versions. The requirements logic used comes from [this documentation](https://guides.cocoapods.org/using/the-podfile.html)'s section on "Specifying Pod Versions", specifically "optimistic operators".