### PR TITLE
Encode user agent as latin1

### DIFF
--- a/ParselyTracker/RequestBuilder.swift
+++ b/ParselyTracker/RequestBuilder.swift
@@ -34,7 +34,10 @@ class RequestBuilder {
             }
             let osDescriptor = String(format: "iOS/%@", UIDevice.current.systemVersion)
             let hardwareString = getHardwareString()
-            userAgent = String(format: "%@ %@ (%@)", appDescriptor, osDescriptor, hardwareString)
+            let userAgentString = String(format: "%@ %@ (%@)", appDescriptor, osDescriptor, hardwareString)
+            // encode the user agent into latin1 in case there are utf8 characters
+            let userAgentData = Data(userAgentString.utf8)
+            userAgent = String(data: userAgentData, encoding: .isoLatin1)
         }
         return userAgent!
     }


### PR DESCRIPTION
FMM has a Bundle Identifier that's made up of arabic characters. I found an example of their iOS app sending requests to mobile proxy by deploying a branch with enhanced logging to one west coast pixel server. In this request the user agent header was an empty string. Since our SDK builds the user agent header without user intervention this lead me to believe that Tornado was dropping the header because of the utf8 characters.

HTTP headers are required to use ASCII-compatible encodings. By encoding the provided string in latin1 no UTF8 characters would be transmitted and the traffic should be attributed to the correct channel.

I spent about two hours trying different approaches to mocking the Bundle class in a unit test. Then I gave up and deployed the enhanced logging branch back to a single pixel server, pointed the demo app in this repository at that single pixel server and changed the demo app bundle identifier to the string of arabic characters from the linked issue. I saw the header come through as expected.

Should resolve: https://github.com/Parsely/web/issues/10482