### PR TITLE
Upgrade Alamofire from 4.8 to 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ stages:
 jobs:
   include:
     - stage: test
-      name: Run Unit Tests (iOS 10.3.1, iPhone 5)
+      name: Run Unit Tests (iOS 10.3.1, iPhone 5s)
       osx_image: xcode11.5
       xcode_workspace: ParselyDemo.xcworkspace
       xcode_scheme: ParselyTrackerTests
-      xcode_destination: platform=iOS Simulator,OS=10.3.1,name=iPhone 5
+      xcode_destination: platform=iOS Simulator,OS=10.3.1,name=iPhone 5s
       before_install:
         - pod repo update
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
   include:
     - stage: test
       name: Run Unit Tests (iOS 10.3.1, iPhone 5)
-      osx_image: xcode10.1
+      osx_image: xcode11.5
       xcode_workspace: ParselyDemo.xcworkspace
       xcode_scheme: ParselyTrackerTests
       xcode_destination: platform=iOS Simulator,OS=10.3.1,name=iPhone 5
@@ -19,7 +19,7 @@ jobs:
         - pod repo update
     - stage: test
       name: Run Unit Tests (iOS 11.4, iPhone X)
-      osx_image: xcode10.1
+      osx_image: xcode11.5
       xcode_workspace: ParselyDemo.xcworkspace
       xcode_scheme: ParselyTrackerTests
       xcode_destination: platform=iOS Simulator,OS=11.4,name=iPhone X

--- a/ParselyDemo/Base.lproj/Main.storyboard
+++ b/ParselyDemo/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,73 +11,72 @@
         <!--First-->
         <scene sceneID="hNz-n2-bh7">
             <objects>
-                <viewController id="9pv-A4-QxB" customClass="FirstViewController" customModule="AnalyticsSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="9pv-A4-QxB" customClass="FirstViewController" customModule="ParselyDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tsR-hK-woN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vUO-Bv-tV7">
-                                <rect key="frame" x="120" y="20" width="134" height="87"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Track Page View"/>
-                                <connections>
-                                    <action selector="didTouchButton:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="YOy-Hg-tnR"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Engaged Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q98-0J-NrD">
-                                <rect key="frame" x="133" y="115" width="110" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e1O-lw-bhX">
-                                <rect key="frame" x="125" y="144" width="125" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                <state key="normal" title="Start Engagement"/>
-                                <connections>
-                                    <action selector="didStartEngagement:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="adj-DK-j1a"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XJm-4u-7bp">
-                                <rect key="frame" x="127" y="166" width="123" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                <state key="normal" title="Stop Engagement"/>
-                                <connections>
-                                    <action selector="didStopEngagement:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="ZXp-d3-Cs1"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Video" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EXy-Td-wT6">
-                                <rect key="frame" x="165" y="204" width="44" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U32-f3-Whx">
-                                <rect key="frame" x="151" y="227" width="71" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Track Play"/>
-                                <connections>
-                                    <action selector="didStartVideo:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="5aK-Dm-HJ3"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AtZ-xE-XPy">
-                                <rect key="frame" x="145" y="254" width="84" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Track Pause"/>
-                                <connections>
-                                    <action selector="didPauseVideo:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="TbX-BH-W7q"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="MXb-TS-o9o">
+                                <rect key="frame" x="125" y="223" width="125" height="221"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vUO-Bv-tV7">
+                                        <rect key="frame" x="0.0" y="0.0" width="125" height="30"/>
+                                        <state key="normal" title="Track Page View"/>
+                                        <connections>
+                                            <action selector="didTouchButton:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="YOy-Hg-tnR"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Engaged Time" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q98-0J-NrD">
+                                        <rect key="frame" x="0.0" y="35" width="125" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e1O-lw-bhX">
+                                        <rect key="frame" x="0.0" y="61" width="125" height="30"/>
+                                        <state key="normal" title="Start Engagement"/>
+                                        <connections>
+                                            <action selector="didStartEngagement:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="adj-DK-j1a"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XJm-4u-7bp">
+                                        <rect key="frame" x="0.0" y="96" width="125" height="30"/>
+                                        <state key="normal" title="Stop Engagement"/>
+                                        <connections>
+                                            <action selector="didStopEngagement:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="ZXp-d3-Cs1"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Video" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EXy-Td-wT6">
+                                        <rect key="frame" x="0.0" y="131" width="125" height="20"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U32-f3-Whx">
+                                        <rect key="frame" x="0.0" y="156" width="125" height="30"/>
+                                        <state key="normal" title="Track Play"/>
+                                        <connections>
+                                            <action selector="didStartVideo:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="5aK-Dm-HJ3"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AtZ-xE-XPy">
+                                        <rect key="frame" x="0.0" y="191" width="125" height="30"/>
+                                        <state key="normal" title="Track Pause"/>
+                                        <connections>
+                                            <action selector="didPauseVideo:" destination="9pv-A4-QxB" eventType="primaryActionTriggered" id="TbX-BH-W7q"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="MXb-TS-o9o" firstAttribute="centerX" secondItem="tsR-hK-woN" secondAttribute="centerX" id="djk-ja-nJ0"/>
+                            <constraint firstItem="MXb-TS-o9o" firstAttribute="centerY" secondItem="tsR-hK-woN" secondAttribute="centerY" id="l6R-7V-cXC"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="PQr-Ze-W5v"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="First" image="first" id="acW-dT-cKf"/>
-                    <connections>
-                        <outlet property="trackPVButton" destination="vUO-Bv-tV7" id="05G-zz-hhe"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W5J-7L-Pyd" sceneMemberID="firstResponder"/>
             </objects>
@@ -88,13 +85,13 @@
         <!--Second-->
         <scene sceneID="wg7-f3-ORb">
             <objects>
-                <viewController id="8rJ-Kc-sve" customClass="SecondViewController" customModule="AnalyticsSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="8rJ-Kc-sve" customClass="SecondViewController" customModule="ParselyDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QS5-Rx-YEW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" text="Second View" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="zEq-FU-wV5">
-                                <rect key="frame" x="87" y="312" width="201.5" height="43"/>
+                                <rect key="frame" x="86.5" y="312" width="202" height="43"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/ParselyDemo/FirstViewController.swift
+++ b/ParselyDemo/FirstViewController.swift
@@ -3,7 +3,6 @@ import os.log
 import ParselyTracker
 
 class FirstViewController: UIViewController {
-    @IBOutlet weak var trackPVButton: UIButton!
     let delegate = UIApplication.shared.delegate as! AppDelegate
     
     override func viewDidLoad() {

--- a/ParselyTracker/HttpClient.swift
+++ b/ParselyTracker/HttpClient.swift
@@ -7,7 +7,7 @@ class HttpClient {
     static func sendRequest(request: ParselyRequest) {
         os_log("Sending request to %s", log: OSLog.tracker, type: .debug, request.url)
         
-        Alamofire.request(request.url, method: .post, parameters: request.params, encoding: JSONEncoding.default, headers: request.headers as? HTTPHeaders).responseJSON {
+        AF.request(request.url, method: .post, parameters: request.params, encoding: JSONEncoding.default, headers: HTTPHeaders(request.headers)).responseJSON {
             (response) in
             if let err = response.error {
                 os_log("Request failed: %s", log: OSLog.tracker, type: .error, err.localizedDescription)

--- a/ParselyTracker/RequestBuilder.swift
+++ b/ParselyTracker/RequestBuilder.swift
@@ -4,7 +4,7 @@ import os.log
 
 struct ParselyRequest {
     var url: String
-    var headers: Dictionary<String, Any>
+    var headers: Dictionary<String, String>
     var params: Dictionary<String, Any>
 }
 
@@ -63,7 +63,7 @@ class RequestBuilder {
         return self._baseURL!
     }
     
-    internal static func buildHeadersDict(events: Array<Event>) -> Dictionary<String, Any> {
+    internal static func buildHeadersDict(events: Array<Event>) -> Dictionary<String, String> {
         let userAgent: String = getUserAgent()
         return ["User-Agent": userAgent]
     }

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ target 'ParselyDemo' do
   use_frameworks!
 
   pod 'SwiftyJSON', '~> 4.2'
-  pod 'Alamofire', '~> 4.8'
+  pod 'Alamofire', '~> 5.1'
   pod 'ReachabilitySwift', '~> 4.3'
   target 'ParselyDemoTests' do
     inherit! :search_paths
@@ -21,7 +21,7 @@ target 'ParselyTracker' do
 
   # Pods for ParselyTracker
   pod 'SwiftyJSON', '~> 4.2'
-  pod 'Alamofire', '~> 4.8'
+  pod 'Alamofire', '~> 5.1'
   pod 'ReachabilitySwift', '~> 4.3'
   target 'ParselyTrackerTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Alamofire (4.8.2)
+  - Alamofire (5.2.1)
   - ReachabilitySwift (4.3.0)
   - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
-  - Alamofire (~> 4.8.2)
-  - ReachabilitySwift (~> 4.3.0)
-  - SwiftyJSON (~> 4.2.0)
+  - Alamofire (~> 5.1)
+  - ReachabilitySwift (~> 4.3)
+  - SwiftyJSON (~> 4.2)
 
 SPEC REPOS:
   trunk:
@@ -15,10 +15,10 @@ SPEC REPOS:
     - SwiftyJSON
 
 SPEC CHECKSUMS:
-  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
+  Alamofire: e911732990610fe89af59ac0077f923d72dc3dfd
   ReachabilitySwift: 408477d1b6ed9779dba301953171e017c31241f3
   SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: 3cec596aa3c663ed0602098e4ef5b6759b237d49
+PODFILE CHECKSUM: 5e7df975e44fa9d1a5b1eb30df9018d4663082cd
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3


### PR DESCRIPTION
- Ugraded Alamofire to 5.1 so projects using the latest version of Alamofire don't have dependency conflicts.
- Made `headers` a `Dictionary<String, String>` so it can be used as a parameter in `HTTPHeaders`'s constructor, the optional cast would always fail.
- Moved them items from the Main storyboard to an `UIStackView` and added some constraints so they show properly across different devices.

Checklist:
- [x] Verified that the application logs `Request succeeded`
- [x] Unit tests passing

It would be better if the Alamofire dependency could be removed, the HttpClient class can be easily converted to use pure Swift and would avoid conflicts with the projects that use this library.