### PR TITLE
Update pixel endpoint and tests

### DIFF
--- a/ParselyTracker/RequestBuilder.swift
+++ b/ParselyTracker/RequestBuilder.swift
@@ -43,9 +43,8 @@ class RequestBuilder {
     }
     
     internal static func buildRequest(events: Array<Event>) -> ParselyRequest? {
-        let now = Date()
         let request = ParselyRequest.init(
-            url: buildPixelEndpoint(now: now),
+            url: buildPixelEndpoint(),
             headers: buildHeadersDict(events: events),
             params: buildParamsDict(events: events)
         )
@@ -53,13 +52,8 @@ class RequestBuilder {
         return request
     }
 
-    internal static func buildPixelEndpoint(now: Date?) -> String {
-        let now: Date = now ?? Date()
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd-HH"
-        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-        let dateString = dateFormatter.string(from: now)
-        self._baseURL = "https://srv-\(dateString).pixel.parsely.com/mobileproxy"
+    internal static func buildPixelEndpoint() -> String {
+        self._baseURL = "https://p1.parsely.com/mobileproxy"
         return self._baseURL!
     }
     

--- a/ParselyTrackerTests/RequestBuilderTests.swift
+++ b/ParselyTrackerTests/RequestBuilderTests.swift
@@ -23,21 +23,16 @@ class RequestBuilderTests: ParselyTestCase {
     }
     
     func testEndpoint() {
-        let endpoint = RequestBuilder.buildPixelEndpoint(now: nil)
+        let endpoint = RequestBuilder.buildPixelEndpoint()
         XCTAssert(endpoint != "", "buildPixelEndpoint should return a non-empty string")
     }
     
     func testBuildPixelEndpoint() {
-        var expected: String = "https://srv-2019-01-01-12.pixel.parsely.com/mobileproxy"
-        let formatter = DateFormatter()
-        formatter.timeZone = TimeZone(abbreviation: "UTC")
-        formatter.dateFormat = "yyyy/MM/dd HH:mm"
-        var now = formatter.date(from: "2019/01/01 12:31")
-        var actual = RequestBuilder.buildPixelEndpoint(now: now)
+        var expected: String = "https://p1.parsely.com/mobileproxy"
+        var actual = RequestBuilder.buildPixelEndpoint()
         XCTAssert(actual == expected, "buildPixelEndpoint should return the correct URL for the given date")
-        now = formatter.date(from: "2019/01/10 12:31")
-        expected = "https://srv-2019-01-10-12.pixel.parsely.com/mobileproxy"
-        actual = RequestBuilder.buildPixelEndpoint(now: now!)
+        expected = "https://p1.parsely.com/mobileproxy"
+        actual = RequestBuilder.buildPixelEndpoint()
         XCTAssert(actual == expected, "buildPixelEndpoint should return the correct URL for the given date")
     }
     
@@ -52,7 +47,7 @@ class RequestBuilderTests: ParselyTestCase {
         let events = makeEvents()
         let request = RequestBuilder.buildRequest(events: events)
         XCTAssertNotNil(request, "buildRequest should return a non-nil value")
-        XCTAssert(request!.url.contains("https://srv-"),
+        XCTAssert(request!.url.contains("https://p1"),
                   "RequestBuilder.buildRequest should return a request with a valid-looking url attribute")
         XCTAssertNotNil(request!.headers,
                         "RequestBuilder.buildRequest should return a request with a non-nil headers attribute")


### PR DESCRIPTION
This updates the SDK to use p1.parsely.com and updates the tests to expect that.