### PR TITLE
Proposal: Flush the event queue without checking reachability?

### DIFF
--- a/ParselyAnalytics.podspec
+++ b/ParselyAnalytics.podspec
@@ -12,5 +12,4 @@ Pod::Spec.new do |s|
   s.source_files           = "ParselyTracker"
   s.framework              = 'Foundation'
   s.dependency               'SwiftyJSON', '~> 4.2'
-  s.dependency               'ReachabilitySwift', '~> 4.3'
 end

--- a/ParselyDemo.xcodeproj/project.pbxproj
+++ b/ParselyDemo.xcodeproj/project.pbxproj
@@ -535,12 +535,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ParselyDemo/Pods-ParselyDemo-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ParselyTracker/EventQueue.swift
+++ b/ParselyTracker/EventQueue.swift
@@ -20,6 +20,11 @@ struct EventQueue<T> {
         os_log("Event pushed into queue", log: OSLog.tracker, type: .debug)
         list.append(element)
     }
+
+    mutating func push<Collection>(contentsOf elements:Collection) where T == Collection.Element, Collection: Sequence {
+        os_log("Events pushed into queue", log: OSLog.tracker, type: .debug)
+        list.append(contentsOf: elements)
+    }
     
     mutating func pop() -> T? {
         if list.isEmpty {

--- a/ParselyTracker/HttpClient.swift
+++ b/ParselyTracker/HttpClient.swift
@@ -2,7 +2,7 @@ import Foundation
 import os.log
 
 class HttpClient {
-    static func sendRequest(request: ParselyRequest) {
+    static func sendRequest(request: ParselyRequest, completion: ((Error?) -> Void)? = nil) {
         os_log("Sending request to %s", log: OSLog.tracker, type: .debug, request.url)
         
         guard let url = URL(string: request.url) else {
@@ -27,6 +27,8 @@ class HttpClient {
             } else {
                 os_log("Request succeeded", log: OSLog.tracker, type: .debug)
             }
+
+            completion?(error)
         }.resume()
     }
 }

--- a/ParselyTrackerTests/EventQueueTests.swift
+++ b/ParselyTrackerTests/EventQueueTests.swift
@@ -19,6 +19,16 @@ class EventQueueTests: ParselyTestCase {
         self.queue.push(31)
         XCTAssert(self.queue.list.count == 32)
     }
+
+    func testPushContentsOf() {
+        self.queue.push(contentsOf: [31])
+        XCTAssert(self.queue.list.count == 32)
+        self.queue.push(contentsOf: [32, 33])
+        XCTAssert(self.queue.list.count == 34)
+        self.queue.push(contentsOf: [34, 35].prefix(1))
+        XCTAssert(self.queue.list.count == 35)
+        XCTAssert(self.queue.list.suffix(4) == [31, 32, 33, 34])
+    }
     
     func testPop() {
         XCTAssert(self.queue.pop() == 0)

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,6 @@ target 'ParselyDemo' do
   use_frameworks!
 
   pod 'SwiftyJSON', '~> 4.2'
-  pod 'ReachabilitySwift', '~> 4.3'
   target 'ParselyDemoTests' do
     inherit! :search_paths
     # Pods for testing
@@ -20,7 +19,6 @@ target 'ParselyTracker' do
 
   # Pods for ParselyTracker
   pod 'SwiftyJSON', '~> 4.2'
-  pod 'ReachabilitySwift', '~> 4.3'
   target 'ParselyTrackerTests' do
     inherit! :search_paths
     # Pods for testing

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,16 @@
 PODS:
-  - ReachabilitySwift (4.3.0)
   - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
-  - ReachabilitySwift (~> 4.3)
   - SwiftyJSON (~> 4.2)
 
 SPEC REPOS:
   trunk:
-    - ReachabilitySwift
     - SwiftyJSON
 
 SPEC CHECKSUMS:
-  ReachabilitySwift: 408477d1b6ed9779dba301953171e017c31241f3
   SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: 158db90ee9af1e3ee33339f20654e277f08ca893
+PODFILE CHECKSUM: 9c29090f1e39cf04229de4bde41256417975242a
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1


### PR DESCRIPTION
# Rationale

I wanted to use the Parse.ly SDK in an app that depends on [connectivity_plus](https://pub.dev/packages/connectivity_plus), but I couldn't compile because of a conflict between Reachability and ReachabilitySwift.

# Description

- Remove the dependency on ReachabilitySwift
- Instead of preflighting requests, try them even when offline
- Keep the existing behavior when there is an internet connection and the request fails (e.g. with a 4xx or 5xx error)
- When the request fails due to lack of network connection, push the events back into the queue for the next flush

I'm eager to implement any changes you'd like to see in this PR.

# How was this tested?

- [x] Run unit tests
- [x] Check for regressions
1. Launch the demo app
2. Create events
3. Put the app into the background
4. Assert the events are posted and the queue is empty
5. Put the app into the foreground and background again
6. Assert that the queue is still empty and no duplicate events are sent
- [x] Check new functionality
1. Launch the demo app
2. Turn off WiFi radio
3. Create events
4. Put the app into the background
5. Assert that the queue still contains the events
6. Turn on WiFi radio
7. Put the app into the foreground and background again
8. Assert the events are posted and the queue is empty
9. Put the app into the foreground and background again
10. Assert that the queue is still empty and no duplicate events are sent
- [x] Assert that the library installs successfully when listed in another app's Podfile

Thanks so much!