### PR TITLE
Fix typecasts which caused first session ts to be 0

### DIFF
--- a/ParselyTracker/Event.swift
+++ b/ParselyTracker/Event.swift
@@ -9,10 +9,10 @@ class Event {
     var idsite: String
     var extra_data: Dictionary<String, Any>?
     var session_id: Int?
-    var session_timestamp: Int?
+    var session_timestamp: UInt64?
     var session_url: String?
     var session_referrer: String?
-    var last_session_timestamp: Int?
+    var last_session_timestamp: UInt64?
     var parsely_site_uuid: String?
     var rand: UInt64!
     
@@ -23,10 +23,10 @@ class Event {
          extra_data: Dictionary<String, Any>?,
          idsite: String = "",
          session_id: Int? = nil,
-         session_timestamp: Int? = nil,
+         session_timestamp: UInt64? = nil,
          session_url: String? = nil,
          session_referrer: String? = nil,
-         last_session_timestamp: Int? = nil
+         last_session_timestamp: UInt64? = nil
     ) {
         self.action = action
         self.url = url
@@ -45,10 +45,10 @@ class Event {
 
     func setSessionInfo(session: Dictionary<String, Any?>) {
         self.session_id = session["session_id"] as? Int ?? 0
-        self.session_timestamp = session["session_ts"] as? Int ?? 0
+        self.session_timestamp = session["session_ts"] as? UInt64 ?? 0
         self.session_url = session["session_url"] as? String ?? ""
         self.session_referrer = session["session_referrer"] as? String ?? ""
-        self.last_session_timestamp = session["last_session_ts"] as? Int ?? 0
+        self.last_session_timestamp = session["last_session_ts"] as? UInt64 ?? 0
     }
 
     func setVisitorInfo(visitorInfo: Dictionary<String, Any>?) {

--- a/ParselyTrackerTests/EventTests.swift
+++ b/ParselyTrackerTests/EventTests.swift
@@ -5,7 +5,7 @@ class EventTests: ParselyTestCase {
     let testInc: Int = 5
     let testTT: Int = 15
     let expectedVisitorID: String = "12345fdffff"
-    let timestampInThePast: Int = 1553372504
+    let timestampInThePast: UInt64 = 1626963869621
     
     let expectedStrings: Dictionary<String, String> = [
         "action": "pageview",
@@ -17,8 +17,10 @@ class EventTests: ParselyTestCase {
         ]
     let expectedInts: Dictionary<String, Int> = [
         "sid": 0,
-        "sts": 1553295726,
-        "slts": 1553295726
+    ]
+    let expectedUInt64s: Dictionary<String, UInt64> = [
+        "sts": 1626963869621,
+        "slts": 1626963869621
     ]
     let extraData: Dictionary<String, String> = [
         "arbitraryParameter1": "testValue",
@@ -34,9 +36,9 @@ class EventTests: ParselyTestCase {
         let eventUnderTest = Event(expectedStrings["action"]!, url: expectedStrings["url"]!,
                                    urlref: expectedStrings["urlref"], metadata: testMetadata,
                                    extra_data: extraData, idsite: expectedStrings["idsite"]!,
-                                   session_id: expectedInts["sid"], session_timestamp: expectedInts["sts"],
+                                   session_id: expectedInts["sid"], session_timestamp: expectedUInt64s["sts"],
                                    session_url: expectedStrings["surl"], session_referrer: expectedStrings["sref"],
-                                   last_session_timestamp: expectedInts["slts"])
+                                   last_session_timestamp: expectedUInt64s["slts"])
         XCTAssertEqual(eventUnderTest.action, expectedStrings["action"],
                        "The action provided in Event initialization should be stored properly")
         XCTAssertEqual(eventUnderTest.url, expectedStrings["url"],
@@ -47,13 +49,13 @@ class EventTests: ParselyTestCase {
                        "The idsite provided in Event initialization should be stored properly")
         XCTAssertEqual(eventUnderTest.session_id, expectedInts["sid"],
                        "The sid provided in Event initialization should be stored properly")
-        XCTAssertEqual(eventUnderTest.session_timestamp, expectedInts["sts"],
+        XCTAssertEqual(eventUnderTest.session_timestamp, expectedUInt64s["sts"],
                        "The sts provided in Event initialization should be stored properly")
         XCTAssertEqual(eventUnderTest.session_url, expectedStrings["surl"],
                        "The surl provided in Event initialization should be stored properly")
         XCTAssertEqual(eventUnderTest.session_referrer, expectedStrings["sref"],
                        "The sref provided in Event initialization should be stored properly")
-        XCTAssertEqual(eventUnderTest.last_session_timestamp, expectedInts["slts"],
+        XCTAssertEqual(eventUnderTest.last_session_timestamp, expectedUInt64s["slts"],
                        "The slts provided in Event initialization should be stored properly")
         XCTAssert(eventUnderTest.rand > timestampInThePast,
                   "The rand of a newly-created Event should be a non-ancient timestamp")
@@ -86,9 +88,9 @@ class EventTests: ParselyTestCase {
         let eventUnderTest = Event(expectedStrings["action"]!, url: expectedStrings["url"]!,
                                    urlref: expectedStrings["urlref"], metadata: testMetadata,
                                    extra_data: extraData, idsite: expectedStrings["idsite"]!,
-                                   session_id: expectedInts["sid"], session_timestamp: expectedInts["sts"],
+                                   session_id: expectedInts["sid"], session_timestamp: expectedUInt64s["sts"],
                                    session_url: expectedStrings["surl"], session_referrer: expectedStrings["sref"],
-                                   last_session_timestamp: expectedInts["slts"])
+                                   last_session_timestamp: expectedUInt64s["slts"])
         eventUnderTest.setVisitorInfo(visitorInfo: ["id": expectedVisitorID])
         let actual: Dictionary<String, Any> = eventUnderTest.toDict()
         for (key, value) in expectedStrings {
@@ -125,16 +127,16 @@ class EventTests: ParselyTestCase {
                                    extra_data: extraData, idsite: expectedStrings["idsite"]!)
         eventUnderTest.setSessionInfo(session:[
             "session_id": expectedInts["sid"],
-            "session_ts": expectedInts["sts"],
-            "last_session_ts": expectedInts["slts"],
+            "session_ts": expectedUInt64s["sts"],
+            "last_session_ts": expectedUInt64s["slts"],
             "session_referrer": expectedStrings["sref"],
             "session_url": expectedStrings["surl"]
         ])
         XCTAssertEqual(eventUnderTest.session_id, expectedInts["sid"],
                        "The sid set via setSessionInfo should be stored properly")
-        XCTAssertEqual(eventUnderTest.session_timestamp, expectedInts["sts"],
+        XCTAssertEqual(eventUnderTest.session_timestamp, expectedUInt64s["sts"],
                        "The sts set via setSessionInfo should be stored properly")
-        XCTAssertEqual(eventUnderTest.last_session_timestamp, expectedInts["slts"],
+        XCTAssertEqual(eventUnderTest.last_session_timestamp, expectedUInt64s["slts"],
                        "The slts set via setSessionInfo should be stored properly")
         XCTAssertEqual(eventUnderTest.session_referrer, expectedStrings["sref"],
                        "The sref set via setSessionInfo should be stored properly")

--- a/ParselyTrackerTests/SessionTests.swift
+++ b/ParselyTrackerTests/SessionTests.swift
@@ -25,6 +25,7 @@ class SessionTests: ParselyTestCase {
                        "The session_referrer of a newly-created session should be the urlref it was initialized with")
         XCTAssertGreaterThan(session["session_ts"] as! UInt64, UInt64(epochTimeInThePast),
                              "The session_ts of a newly-created session should be non-ancient")
+        XCTAssertNotEqual(session["session_ts"] as! UInt64, 0, "The session_ts of a newly-created session should not be zero")
         XCTAssertGreaterThan(session["last_session_ts"] as! UInt64, UInt64(epochTimeInThePast),
                              "The last_session_ts of a newly-created session should be non-ancient")
     }

--- a/ParselyTrackerTests/SessionTests.swift
+++ b/ParselyTrackerTests/SessionTests.swift
@@ -6,7 +6,7 @@ class SessionTests: ParselyTestCase {
     let sessionStorageKey = "_parsely_session_identifier"
     let testInitialUrl = "http://parsely-test.com/123"
     let testSubsequentUrl = "http://parsely-test.com/"
-    let epochTimeInThePast = 1553459222
+    let epochTimeInThePast = 1626963869621
     
     override func setUp() {
         super.setUp()

--- a/ParselyTrackerTests/SessionTests.swift
+++ b/ParselyTrackerTests/SessionTests.swift
@@ -6,7 +6,7 @@ class SessionTests: ParselyTestCase {
     let sessionStorageKey = "_parsely_session_identifier"
     let testInitialUrl = "http://parsely-test.com/123"
     let testSubsequentUrl = "http://parsely-test.com/"
-    let epochTimeInThePast = 1626963869621
+    let epochTimeInThePast:UInt64 = 1626963869621
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
This fixes a bug where initial session timestamps were zero.

resolves: https://github.com/Parsely/web/issues/12035