### PR TITLE
Warning-free installation under Swift 5

### DIFF
--- a/ParselyAnalytics.podspec
+++ b/ParselyAnalytics.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name                   = "ParselyAnalytics"
   s.version                = "0.0.11-dev"
-  s.swift_version          = "4.2"
+  s.swift_versions         = ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
   s.summary                = "Parsely analytics integration for iOS"
   s.homepage               = "https://www.parse.ly/help/integration/ios-sdk/"
   s.license                = "Apache License, Version 2.0"

--- a/ParselyTrackerTests/RequestBuilderTests.swift
+++ b/ParselyTrackerTests/RequestBuilderTests.swift
@@ -73,9 +73,9 @@ class RequestBuilderTests: ParselyTestCase {
     
     func testGetHardwareString() {
         let result = RequestBuilder.getHardwareString()
-        let expected = "x86_64"
-        XCTAssertEqual(result, expected,
-                       "The result of RequestBuilder.getHardwareString should accurately represent the simulator hardware"
+        let expected = Set(["x86_64", "arm64"])
+        XCTAssertTrue(expected.contains(result),
+                    "The result of RequestBuilder.getHardwareString should accurately represent the simulator hardware"
         )
     }
     


### PR DESCRIPTION
Hi there! I was hoping you might be interested in a PR to silence a compiler warning on Swift 5 projects.

## Rationale

This PR adds swift versions 5.0 through 5.5 to the podspec to silence an Xcode warning, "Conversion to Swift 5 is available."

## How was this tested?

- I ran the unit tests. These needed a small update for M1.
- I created a separate demo app and pointed it to the local ParselyAnalytics.podspec. I built and ran it under iOS 10.1 and Swift 4.2, then under iOS 15.0 and Swift 5.0.