### PR TITLE
Relax a couple of time assertions in unit tests

### DIFF
--- a/Tests/SamplerTests.swift
+++ b/Tests/SamplerTests.swift
@@ -61,7 +61,9 @@ class SamplerTests: ParselyTestCase {
         Timer.scheduledTimer(withTimeInterval: heartbeatDeliveryInterval, repeats: false) { timer in
             expectation.fulfill()
         }
-        waitForExpectations(timeout: heartbeatDeliveryInterval, handler: nil)
+        // Wait slightly longer to reduce the race between waiting for the `expectation` to be
+        // fulfilled and the fulfillment.
+        waitForExpectations(timeout: heartbeatDeliveryInterval + 0.01, handler: nil)
         
         let actualUpdatedInterval = samplerUnderTest!.heartbeatInterval
         // This value depends on heartbeatInterval, and two magic numbers in the implementation.

--- a/Tests/SamplerTests.swift
+++ b/Tests/SamplerTests.swift
@@ -162,8 +162,12 @@ class SamplerTests: ParselyTestCase {
         
         let accumulatedTime:TimeInterval = samplerUnderTest!.accumulators["sampler-test"]!.accumulatedTime
         samplerUnderTest!.pause()
-        XCTAssert(accumulatedTime >= assertionTimeout - acceptableDifference,
-                  "The sampler should accumulate time constantly after a call to trackKey")
+        XCTAssertEqual(
+            accumulatedTime,
+            assertionTimeout,
+            accuracy: acceptableDifference,
+            "The sampler should accumulate time constantly after a call to trackKey"
+        )
         
         let secondExpectation = self.expectation(description: "Paused sampling")
         Timer.scheduledTimer(withTimeInterval: assertionTimeout, repeats: false) { timer in
@@ -172,6 +176,11 @@ class SamplerTests: ParselyTestCase {
         waitForExpectations(timeout: assertionTimeout + acceptableDifference, handler: nil)
         
         let secondAccumulatedTime: TimeInterval = samplerUnderTest!.accumulators["sampler-test"]!.accumulatedTime
-        XCTAssert(secondAccumulatedTime <= assertionTimeout, "AccumulatedTime was \(secondAccumulatedTime)")
+        XCTAssertEqual(
+            secondAccumulatedTime,
+            assertionTimeout,
+            accuracy: acceptableDifference,
+            "AccumulatedTime was \(secondAccumulatedTime)"
+        )
     }
 }


### PR DESCRIPTION
This PR hopefully addresses a couple flaky unit tests @cwisecarver [noticed in the other PR](https://github.com/Parsely/AnalyticsSDK-iOS/pull/77#pullrequestreview-1394708413).