### PR TITLE
Remove force unwrap from `VideoManager.swift`

### DIFF
--- a/Sources/Video.swift
+++ b/Sources/Video.swift
@@ -29,7 +29,7 @@ class VideoManager: Sampler {
         let roundedSecs: Int = Int(data.accumulatedTime)
         let totalMs: Int = Int(data.totalTime.milliseconds())
 
-        var curVideo = trackedVideos[data.key]!
+        guard var curVideo = trackedVideos[data.key] else { return }
         let event = Heartbeat(
             "vheartbeat",
             url: curVideo.url,


### PR DESCRIPTION
We are getting some crashes from ParselySDK about this force unwrapping.

This is not a consistently reproducible bug, but it happens when the user goes to the background and reopens the application. 

In Firebase Crashlytics log We are getting

```
Falha: com.apple.root.user-initiated-qos
EXC_BREAKPOINT 0x0000000104826a78

Video.swift

VideoManager.heartbeatFn(data:enableHeartbeats:)

Sampler.swift - Line 151

Sampler.sendHeartbeat(key:) + 151

Sampler.sendHeartbeats() + 164

closure #1 in Parsely.suspendExecution(_:) + 82
```
