### PR TITLE
Remove unnecessary `Optional`s, IUOs, and the like from `Event`

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -51,9 +51,11 @@ class Event {
     }
 
     func setVisitorInfo(visitorInfo: Dictionary<String, Any>?) {
-        if let visitor = visitorInfo {
-            self.parsely_site_uuid = (visitor["id"] as! String)
+        guard let visitor = visitorInfo?["id"] as? String else {
+            return
         }
+
+        parsely_site_uuid = visitor
     }
 
     func toDict() -> Dictionary<String,Any> {

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 class Event {
-    var action: String
-    var url: String
-    var urlref: String
-    var data: Dictionary<String, Any>!
-    var metadata: ParselyMetadata?
-    var idsite: String
-    var extra_data: Dictionary<String, Any>?
-    var session_id: Int?
-    var session_timestamp: UInt64?
-    var session_url: String?
-    var session_referrer: String?
-    var last_session_timestamp: UInt64?
-    var parsely_site_uuid: String?
-    var rand: UInt64!
+    let action: String
+    let url: String
+    let urlref: String
+    private(set) var data: Dictionary<String, Any>!
+    let metadata: ParselyMetadata?
+    let idsite: String
+    let extra_data: Dictionary<String, Any>?
+    private(set) var session_id: Int?
+    private(set) var session_timestamp: UInt64?
+    private(set) var session_url: String?
+    private(set) var session_referrer: String?
+    private(set) var last_session_timestamp: UInt64?
+    private(set) var parsely_site_uuid: String?
+    let rand: UInt64!
     
     init(_ action: String,
          url: String,

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -69,8 +69,8 @@ class Event {
         var data: [String: Any] = extra_data
         data["ts"] = self.rand
         
-        if parsely_site_uuid != nil {
-            data["parsely_site_uuid"] = parsely_site_uuid!
+        if let parsely_site_uuid {
+            data["parsely_site_uuid"] = parsely_site_uuid
         }
         
         params["data"] = data

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -81,14 +81,16 @@ class Event {
                 params["metadata"] = metasDict
             }
         }
-        
-        if self.session_id != nil {
-            params["sid"] = self.session_id
-            params["sts"] = self.session_timestamp
-            params["surl"] = self.session_url
-            params["sref"] = self.session_referrer
-            params["slts"] = self.last_session_timestamp
+
+        guard let session_id else {
+            return params
         }
+
+        params["sid"] = session_id
+        params["sts"] = session_timestamp
+        params["surl"] = session_url
+        params["sref"] = session_referrer
+        params["slts"] = last_session_timestamp
 
         return params
     }

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -14,7 +14,7 @@ class Event {
     private(set) var session_referrer: String?
     private(set) var last_session_timestamp: UInt64?
     private(set) var parsely_site_uuid: String?
-    let rand: UInt64!
+    let rand: UInt64
     
     init(_ action: String,
          url: String,
@@ -39,8 +39,8 @@ class Event {
         self.session_url = session_url
         self.session_referrer = session_referrer
         self.last_session_timestamp = last_session_timestamp
+        // Note that, while this value will likely always be different at runtime, is not truly random.
         self.rand = Date().millisecondsSince1970
-
     }
 
     func setSessionInfo(session: Dictionary<String, Any?>) {

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -4,7 +4,6 @@ class Event {
     let action: String
     let url: String
     let urlref: String
-    private(set) var data: Dictionary<String, Any>!
     let metadata: ParselyMetadata?
     let idsite: String
     let extra_data: Dictionary<String, Any>?
@@ -65,7 +64,7 @@ class Event {
             "idsite": self.idsite,
         ]
         
-        data = extra_data ?? [:]
+        var data: [String: Any] = extra_data ?? [:]
         data["ts"] = self.rand
         
         if parsely_site_uuid != nil {
@@ -74,7 +73,6 @@ class Event {
         
         params["data"] = data
 
-        
         if let metas = self.metadata {
             let metasDict = metas.toDict()
             if !metasDict.isEmpty {

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -6,7 +6,7 @@ class Event {
     let urlref: String
     let metadata: ParselyMetadata?
     let idsite: String
-    let extra_data: Dictionary<String, Any>?
+    let extra_data: Dictionary<String, Any>
     private(set) var session_id: Int?
     private(set) var session_timestamp: UInt64?
     private(set) var session_url: String?
@@ -32,7 +32,7 @@ class Event {
         self.urlref = urlref ?? ""
         self.idsite = idsite
         self.metadata = metadata
-        self.extra_data = extra_data
+        self.extra_data = extra_data ?? [:]
         self.session_id = session_id
         self.session_timestamp = session_timestamp
         self.session_url = session_url
@@ -64,7 +64,7 @@ class Event {
             "idsite": self.idsite,
         ]
         
-        var data: [String: Any] = extra_data ?? [:]
+        var data: [String: Any] = extra_data
         data["ts"] = self.rand
         
         if parsely_site_uuid != nil {

--- a/Tests/EventTests.swift
+++ b/Tests/EventTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 @testable import ParselyAnalytics
 import XCTest
 
@@ -66,8 +67,30 @@ class EventTests: XCTestCase {
                   "The rand of a newly-created Event should be a non-ancient timestamp")
         XCTAssert(eventUnderTest.metadata! === testMetadata,
                   "The metadata procided in Event initialization should be stored properly")
-        let extraDataIsEquivalent: Bool = NSDictionary(dictionary: eventUnderTest.extra_data!).isEqual(to: extraData)
+        let extraDataIsEquivalent: Bool = NSDictionary(dictionary: eventUnderTest.extra_data).isEqual(to: extraData)
         XCTAssert(extraDataIsEquivalent, "The extra_data procided in Event initialization should be stored properly")
+    }
+
+    func testEventDefaultValues() {
+        let event = Event(
+            "action",
+            url: "a_url",
+            urlref: .none,
+            metadata: .none,
+            extra_data: .none
+        )
+
+        XCTAssertEqual(event.action, "action")
+        XCTAssertEqual(event.url, "a_url") // Note that this String is not a valid URL...
+        XCTAssertEqual(event.urlref, "")
+        XCTAssertEqual(event.idsite, "")
+        XCTAssertNil(event.metadata)
+        XCTAssertEqual(event.session_id, .none)
+        XCTAssertEqual(event.session_timestamp, .none)
+        XCTAssertEqual(event.session_referrer, .none)
+        XCTAssertEqual(event.session_url, .none)
+        XCTAssertEqual(event.last_session_timestamp, .none)
+        expect(event.extra_data).to(beEmpty())
     }
 
     func testHeartbeatEvents() {

--- a/Tests/RequestBuilderTests.swift
+++ b/Tests/RequestBuilderTests.swift
@@ -86,6 +86,6 @@ class RequestBuilderTests: XCTestCase {
         // be in the format
         //
         // xctest/<Xcode version> iOS/<iOS version> (<architecture>)
-        expect(RequestBuilder.getUserAgent()).to(match("xctest\\/\\d+\\.\\d+ iOS\\/\\d+\\.\\d+ (.*)"))
+        expect(RequestBuilder.getUserAgent()).to(match("xctest\\/\\d+\\.\\d+(\\.\\d+)? iOS\\/\\d+\\.\\d+ (.*)"))
     }
 }


### PR DESCRIPTION
The idea is to make the code "tighter", less flexible towards undesired state, so that it should be harder for runtime issues due to unexpected nils to occurr.