### PR TITLE
Add optional page_type parameter to ParselyMetadata for iOS SDK

### DIFF
--- a/Sources/Metadata.swift
+++ b/Sources/Metadata.swift
@@ -9,6 +9,7 @@ public class ParselyMetadata {
     var section: String?
     var tags: Array<String>?
     var duration: TimeInterval?
+    var page_type: String?
     
     /**
      A class to manage and re-use metadata. Metadata contained in an instance of this
@@ -22,6 +23,7 @@ public class ParselyMetadata {
      - Parameter section: Same as section for website integration.
      - Parameter tags: Up to 20 tags on an event are allowed.
      - Parameter duration: Durations passed explicitly to trackVideoStart take precedence over any in metadata.
+     - Parameter page_type: The type of page being tracked
     */
     public init(canonical_url: String? = nil,
          pub_date: Date? = nil,
@@ -30,7 +32,8 @@ public class ParselyMetadata {
          image_url: String? = nil,
          section: String? = nil,
          tags: Array<String>? = nil,
-         duration: TimeInterval? = nil) {
+         duration: TimeInterval? = nil,
+         page_type: String? = nil) {
         self.canonical_url = canonical_url
         self.pub_date = pub_date
         self.title = title
@@ -39,6 +42,7 @@ public class ParselyMetadata {
         self.section = section
         self.tags = tags
         self.duration = duration
+        self.page_type = page_type
     }
     
     func toDict() -> Dictionary<String, Any> {
@@ -67,6 +71,9 @@ public class ParselyMetadata {
         }
         if let duration {
             metas["duration"] = duration
+        }
+        if let page_type {
+            metas["page_type"] = page_type
         }
         
         return metas


### PR DESCRIPTION
## ⁉️ What ⁉️

This PR adds a new optional parameter, `page_type`, to the `ParselyMetadata` class in the iOS SDK. This is being done in response to a client question/request (see linked issue below). An analogous companion PR for the Android SDK will be linked here once the PR is created.

## 🤔 Why 🤔
Resolves https://github.com/Parsely/web/issues/13450

## ✔️ TODOs ✔️
- [ ] Attend Chris' office hours to figure out how to test this change
- [ ] Get an understanding of how our iOS SDK releases are handled before getting this PR merged 